### PR TITLE
Add offline archive support

### DIFF
--- a/connectionsapi.lua
+++ b/connectionsapi.lua
@@ -6,8 +6,6 @@ local datetime = require("datetime")
 local DataStorage = require("datastorage")
 local lfs = require("libs/libkoreader-lfs")
 
-local MAX_ARCHIVE = 100
-
 local function get_archive_dir()
 	local dir = DataStorage:getDataDir() .. "/connections"
 	lfs.mkdir(dir)
@@ -87,18 +85,6 @@ local function delete_puzzle(date)
 	save_state(state)
 end
 
-local function enforce_max_archive()
-	local state = load_state()
-	table.sort(state.downloaded)
-	while #state.downloaded > MAX_ARCHIVE do
-		local oldest = state.downloaded[1]
-		local path = get_archive_dir() .. "/" .. oldest .. ".json"
-		os.remove(path)
-		table.remove(state.downloaded, 1)
-	end
-	save_state(state)
-end
-
 local function parse_puzzle(resp)
 	local categories = resp.categories
 	local cards = {}
@@ -150,7 +136,6 @@ local function get_connections_puzzle()
 	end
 
 	save_puzzle(date, resp)
-	enforce_max_archive()
 
 	return parse_puzzle(resp), date
 end
@@ -207,13 +192,31 @@ local function bulk_download(num_puzzles)
 		day_offset = day_offset + 1
 	end
 
-	enforce_max_archive()
 	return downloaded_count, skipped_count
 end
 
 local function get_archive_info()
 	local state = load_state()
 	return #state.downloaded, #state.played
+end
+
+local function delete_all_archived()
+	local dir = get_archive_dir()
+	local state = load_state()
+	for _, date in ipairs(state.downloaded) do
+		os.remove(dir .. "/" .. date .. ".json")
+	end
+	state.downloaded = {}
+	save_state(state)
+end
+
+local function reset_history()
+	local dir = get_archive_dir()
+	local state = load_state()
+	for _, date in ipairs(state.downloaded) do
+		os.remove(dir .. "/" .. date .. ".json")
+	end
+	os.remove(get_state_path())
 end
 
 return {
@@ -223,4 +226,6 @@ return {
 	mark_played = mark_played,
 	bulk_download = bulk_download,
 	get_archive_info = get_archive_info,
+	delete_all_archived = delete_all_archived,
+	reset_history = reset_history,
 }

--- a/connectionsapi.lua
+++ b/connectionsapi.lua
@@ -3,6 +3,129 @@ local ltn12 = require("ltn12")
 local json = require("json")
 local logger = require("logger")
 local datetime = require("datetime")
+local DataStorage = require("datastorage")
+local lfs = require("libs/libkoreader-lfs")
+
+local MAX_ARCHIVE = 100
+
+local function get_archive_dir()
+	local dir = DataStorage:getDataDir() .. "/connections"
+	lfs.mkdir(dir)
+	return dir
+end
+
+local function get_state_path()
+	return get_archive_dir() .. "/state.json"
+end
+
+local function load_state()
+	local path = get_state_path()
+	local f = io.open(path, "r")
+	if f == nil then
+		return { downloaded = {}, played = {} }
+	end
+	local content = f:read("*a")
+	f:close()
+	local ok, state = pcall(json.decode, content)
+	if not ok or state == nil then
+		return { downloaded = {}, played = {} }
+	end
+	if state.downloaded == nil then state.downloaded = {} end
+	if state.played == nil then state.played = {} end
+	return state
+end
+
+local function save_state(state)
+	local path = get_state_path()
+	local f = io.open(path, "w")
+	if f == nil then
+		logger.err("connections: failed to write state file")
+		return
+	end
+	f:write(json.encode(state))
+	f:close()
+end
+
+local function list_has(list, value)
+	for _, v in ipairs(list) do
+		if v == value then return true end
+	end
+	return false
+end
+
+local function save_puzzle(date, raw_resp)
+	local path = get_archive_dir() .. "/" .. date .. ".json"
+	local f = io.open(path, "w")
+	if f == nil then
+		logger.err("connections: failed to save puzzle " .. date)
+		return false
+	end
+	f:write(json.encode(raw_resp))
+	f:close()
+
+	local state = load_state()
+	if not list_has(state.downloaded, date) then
+		table.insert(state.downloaded, date)
+		table.sort(state.downloaded)
+		save_state(state)
+	end
+	return true
+end
+
+local function delete_puzzle(date)
+	local path = get_archive_dir() .. "/" .. date .. ".json"
+	os.remove(path)
+
+	local state = load_state()
+	local new_downloaded = {}
+	for _, d in ipairs(state.downloaded) do
+		if d ~= date then
+			table.insert(new_downloaded, d)
+		end
+	end
+	state.downloaded = new_downloaded
+	save_state(state)
+end
+
+local function enforce_max_archive()
+	local state = load_state()
+	table.sort(state.downloaded)
+	while #state.downloaded > MAX_ARCHIVE do
+		local oldest = state.downloaded[1]
+		local path = get_archive_dir() .. "/" .. oldest .. ".json"
+		os.remove(path)
+		table.remove(state.downloaded, 1)
+	end
+	save_state(state)
+end
+
+local function parse_puzzle(resp)
+	local categories = resp.categories
+	local cards = {}
+	for _, category in ipairs(categories) do
+		for _, card in ipairs(category.cards) do
+			cards[card.position + 1] = card.content
+		end
+	end
+
+	return {
+		categories = categories,
+		cards = cards,
+		editor = resp.editor,
+		print_date = resp.print_date,
+	}
+end
+
+local function load_puzzle(date)
+	local path = get_archive_dir() .. "/" .. date .. ".json"
+	local f = io.open(path, "r")
+	if f == nil then return nil end
+	local content = f:read("*a")
+	f:close()
+	local ok, resp = pcall(json.decode, content)
+	if not ok or resp == nil then return nil end
+	return parse_puzzle(resp), date
+end
 
 local function get_connections_cards(date)
 	local sink = {}
@@ -26,22 +149,78 @@ local function get_connections_puzzle()
 		return nil
 	end
 
-	local categories = resp.categories
-	local cards = {}
-	for _, category in ipairs(categories) do
-		for _, card in ipairs(category.cards) do
-			cards[card.position + 1] = card.content
+	save_puzzle(date, resp)
+	enforce_max_archive()
+
+	return parse_puzzle(resp), date
+end
+
+local function mark_played(date)
+	local state = load_state()
+	if not list_has(state.played, date) then
+		table.insert(state.played, date)
+	end
+	-- Remove from downloaded list
+	local new_downloaded = {}
+	for _, d in ipairs(state.downloaded) do
+		if d ~= date then
+			table.insert(new_downloaded, d)
 		end
 	end
+	state.downloaded = new_downloaded
+	save_state(state)
+	-- Delete the puzzle file
+	os.remove(get_archive_dir() .. "/" .. date .. ".json")
+end
 
-	return {
-		categories = categories,
-		cards = cards,
-		editor = resp.editor,
-		print_date = resp.print_date,
-	}
+local function get_latest_unplayed()
+	local state = load_state()
+	local downloaded = state.downloaded
+	table.sort(downloaded)
+	-- iterate from newest to oldest
+	for i = #downloaded, 1, -1 do
+		if not list_has(state.played, downloaded[i]) then
+			return load_puzzle(downloaded[i])
+		end
+	end
+	return nil
+end
+
+local function bulk_download(num_puzzles)
+	local state = load_state()
+	local now = os.time()
+	local downloaded_count = 0
+	local skipped_count = 0
+	local day_offset = 0
+
+	while downloaded_count < num_puzzles and day_offset < 365 do
+		local date = datetime.secondsToDate(now - day_offset * 86400)
+		if list_has(state.downloaded, date) or list_has(state.played, date) then
+			skipped_count = skipped_count + 1
+		else
+			local resp = get_connections_cards(date)
+			if resp ~= nil then
+				save_puzzle(date, resp)
+				downloaded_count = downloaded_count + 1
+			end
+		end
+		day_offset = day_offset + 1
+	end
+
+	enforce_max_archive()
+	return downloaded_count, skipped_count
+end
+
+local function get_archive_info()
+	local state = load_state()
+	return #state.downloaded, #state.played
 end
 
 return {
 	get_connections_puzzle = get_connections_puzzle,
+	load_puzzle = load_puzzle,
+	get_latest_unplayed = get_latest_unplayed,
+	mark_played = mark_played,
+	bulk_download = bulk_download,
+	get_archive_info = get_archive_info,
 }

--- a/connectionsview.lua
+++ b/connectionsview.lua
@@ -17,6 +17,7 @@ local UIManager = require("ui/uimanager")
 local VerticalGroup = require("ui/widget/verticalgroup")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local _ = require("gettext")
+local api = require("connectionsapi")
 local logger = require("logger")
 local math = require("math")
 
@@ -25,6 +26,8 @@ local ConnectionsWidget = WidgetContainer:extend({
 	height = nil,
 	color = Blitbuffer.COLOR_BLACK,
 	puzzle = nil,
+	puzzle_date = nil,
+	on_next_puzzle = nil,
 })
 
 function ConnectionsWidget:init()
@@ -312,10 +315,23 @@ function ConnectionsWidget:getContent()
 		end,
 	})
 
+	self.next_puzzle_button = Button:new({
+		text = "Next Puzzle",
+		enabled = false,
+		margin = Screen:scaleBySize(5),
+		callback = function()
+			if self.on_next_puzzle then
+				self:onClose()
+				self.on_next_puzzle()
+			end
+		end,
+	})
+
 	local actions = HorizontalGroup:new({
 		self.shuffle_button,
 		self.deselect_all_button,
 		self.submit_button,
+		self.next_puzzle_button,
 	})
 
 	return VerticalGroup:new({
@@ -500,19 +516,26 @@ local function notify(msg)
 end
 
 function ConnectionsWidget:show_end_message()
-	self.shuffle_button:disable()
-	UIManager:setDirty(self, "ui", self.dimen)
-	if self.lives == 4 then
-		UIManager:show(notify("Perfect"))
-	elseif self.lives == 3 then
-		UIManager:show(notify("Great"))
-	elseif self.lives == 2 then
-		UIManager:show(notify("Solid"))
-	elseif self.lives == 1 then
-		UIManager:show(notify("Phew"))
-	else
-		UIManager:show(notify("Next Time"))
+	if self.puzzle_date then
+		api.mark_played(self.puzzle_date)
 	end
+	self.shuffle_button:disable()
+	self.submit_button:disable()
+	self.deselect_all_button:disable()
+	if self.on_next_puzzle then
+		self.next_puzzle_button:enable()
+		UIManager:setDirty(self, "fast", self.next_puzzle_button.dimen)
+	end
+	UIManager:setDirty(self, "ui", self.dimen)
+
+	local msg
+	if self.lives == 4 then msg = "Perfect!"
+	elseif self.lives == 3 then msg = "Great!"
+	elseif self.lives == 2 then msg = "Solid!"
+	elseif self.lives == 1 then msg = "Phew!"
+	else msg = "Next Time!" end
+
+	UIManager:show(Notification:new({ text = msg, timeout = 5 }))
 end
 
 function ConnectionsWidget:check_selected()

--- a/main.lua
+++ b/main.lua
@@ -7,6 +7,7 @@ This plugin lets you play Connections in KOReader.
 
 local ConnectionsWidget = require("connectionsview")
 local InfoMessage = require("ui/widget/infomessage")
+local InputDialog = require("ui/widget/inputdialog")
 local NetworkMgr = require("ui/network/manager")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
@@ -23,23 +24,95 @@ function NYTConnections:init()
 	self.ui.menu:registerToMainMenu(self)
 end
 
-local function start_game()
-	NetworkMgr:runWhenOnline(function()
-		local puzzle = api.get_connections_puzzle()
-		NetworkMgr:afterWifiAction()
+local start_game
+
+local function show_puzzle(puzzle, date)
+	UIManager:show(ConnectionsWidget:new({ puzzle = puzzle, puzzle_date = date, on_next_puzzle = start_game }))
+end
+
+function start_game()
+	local puzzle, date = api.get_latest_unplayed()
+	if puzzle ~= nil then
+		show_puzzle(puzzle, date)
+	elseif NetworkMgr:isOnline() then
+		puzzle, date = api.get_connections_puzzle()
 		if puzzle == nil then
-			UIManager:show(InfoMessage:new({ text = "failed to get today’s puzzle" }))
+			UIManager:show(InfoMessage:new({ text = _("Failed to get today’s puzzle.") }))
 		else
-			UIManager:show(ConnectionsWidget:new({ puzzle = puzzle }))
+			show_puzzle(puzzle, date)
 		end
-	end)
+	else
+		UIManager:show(InfoMessage:new({ text = _("No unplayed puzzles available. Go online and use Download Puzzles first.") }))
+	end
+end
+
+local function download_puzzles()
+	local dialog
+	dialog = InputDialog:new({
+		title = _("Download Puzzles"),
+		input = "30",
+		input_hint = _("Number of days"),
+		input_type = "number",
+		buttons = {
+			{
+				{
+					text = _("Cancel"),
+					id = "close",
+					callback = function()
+						UIManager:close(dialog)
+					end,
+				},
+				{
+					text = _("Download"),
+					is_enter_default = true,
+					callback = function()
+						local num = tonumber(dialog:getInputText())
+						UIManager:close(dialog)
+						if num == nil or num < 1 then
+							UIManager:show(InfoMessage:new({ text = _("Please enter a valid number.") }))
+							return
+						end
+						NetworkMgr:runWhenOnline(function()
+							local downloaded, skipped = api.bulk_download(num)
+							NetworkMgr:afterWifiAction()
+							UIManager:show(InfoMessage:new({
+								text = string.format(_("Downloaded %d puzzles, skipped %d already archived."), downloaded, skipped),
+							}))
+						end)
+					end,
+				},
+			},
+		},
+	})
+	UIManager:show(dialog)
+	dialog:onShowKeyboard()
+end
+
+local function archive_info()
+	local total, played = api.get_archive_info()
+	UIManager:show(InfoMessage:new({
+		text = string.format(_("Archived: %d puzzles\nPlayed: %d\nUnplayed: %d"), total, played, total - played),
+	}))
 end
 
 function NYTConnections:addToMainMenu(menu_items)
 	menu_items.nytconnections = {
-		text = _("NYTConnections"),
+		text = _("NYT Connections"),
 		sorting_hint = "tools",
-		callback = start_game,
+		sub_item_table = {
+			{
+				text = _("Play"),
+				callback = start_game,
+			},
+			{
+				text = _("Download Puzzles"),
+				callback = download_puzzles,
+			},
+			{
+				text = _("Archive Info"),
+				callback = archive_info,
+			},
+		},
 	}
 end
 

--- a/main.lua
+++ b/main.lua
@@ -5,6 +5,7 @@ This plugin lets you play Connections in KOReader.
 --]]
 --
 
+local ConfirmBox = require("ui/widget/confirmbox")
 local ConnectionsWidget = require("connectionsview")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
@@ -95,6 +96,28 @@ local function archive_info()
 	}))
 end
 
+local function delete_archived()
+	UIManager:show(ConfirmBox:new({
+		text = _("Delete all archived puzzles? Play history will be kept."),
+		ok_text = _("Delete"),
+		ok_callback = function()
+			api.delete_all_archived()
+			UIManager:show(InfoMessage:new({ text = _("Archived puzzles deleted.") }))
+		end,
+	}))
+end
+
+local function reset_history()
+	UIManager:show(ConfirmBox:new({
+		text = _("Reset all data? This deletes archived puzzles and play history."),
+		ok_text = _("Reset"),
+		ok_callback = function()
+			api.reset_history()
+			UIManager:show(InfoMessage:new({ text = _("All data reset.") }))
+		end,
+	}))
+end
+
 function NYTConnections:addToMainMenu(menu_items)
 	menu_items.nytconnections = {
 		text = _("NYT Connections"),
@@ -109,8 +132,21 @@ function NYTConnections:addToMainMenu(menu_items)
 				callback = download_puzzles,
 			},
 			{
-				text = _("Archive Info"),
-				callback = archive_info,
+				text = _("Settings"),
+				sub_item_table = {
+					{
+						text = _("Archive Info"),
+						callback = archive_info,
+					},
+					{
+						text = _("Delete Archived Puzzles"),
+						callback = delete_archived,
+					},
+					{
+						text = _("Reset History"),
+						callback = reset_history,
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Adds offline play support with puzzle archiving, so you can download puzzles ahead of time and play without an internet connection.

### New features

- **Bulk download**: Download multiple puzzles at once for offline play
- **Offline play**: Automatically picks the latest unplayed puzzle from the archive
- **Smart downloading**: Skips puzzles you've already played, goes further back in time to find unplayed ones
- **Auto-cleanup**: Played puzzle files are automatically deleted from disk after completion (history retained to prevent re-downloading)
- **Next Puzzle button**: Chain puzzles from the action bar without returning to the menu
- **Settings submenu**: Archive Info, Delete Archived Puzzles, and Reset History

### Menu structure

The plugin now uses a submenu under Tools:

```
NYT Connections
  ├── Play              → Plays the latest unplayed archived puzzle
  ├── Download Puzzles  → Download N unplayed puzzles for offline use
  └── Settings
      ├── Archive Info           → Shows downloaded / played / unplayed counts
      ├── Delete Archived Puzzles → Removes all downloaded puzzle files (keeps history)
      └── Reset History          → Wipes everything (puzzles + play history)
```

## Usage walkthrough

### 1. Download puzzles

Go to **Tools → NYT Connections → Download Puzzles**. Enter the number of puzzles you want (e.g., 14). The plugin connects to WiFi, downloads that many unplayed puzzles, and saves them locally.

If you've already played recent puzzles, the downloader automatically skips those dates and goes further back to find ones you haven't played yet.

### 2. Play offline

Go to **Tools → NYT Connections → Play**. The plugin loads the latest unplayed puzzle from your archive — no WiFi needed.

If the archive is empty and you're online, it falls back to fetching today's puzzle directly.

### 3. Chain puzzles

After completing a puzzle, the **Next Puzzle** button in the action bar becomes active. Tap it to immediately load the next unplayed puzzle without going back to the menu. Use the **X** button in the title bar to exit when you're done.

### 4. Check your archive

Go to **Tools → NYT Connections → Settings → Archive Info** to see:
- How many puzzles are archived
- How many you've played
- How many are left to play

### 5. Storage

Puzzles are stored in `{KOReader data dir}/connections/` as individual JSON files (~800 bytes each). A `state.json` file tracks download history and played status.

- Played puzzle files are automatically deleted after completion to save space
- Download history is preserved so puzzles are never re-downloaded
- Manual cleanup options available in Settings (delete archived puzzles or reset all data)